### PR TITLE
pref: Excludes device memory by default.

### DIFF
--- a/fingerprint2.js
+++ b/fingerprint2.js
@@ -269,6 +269,8 @@
     excludes: {
       // Unreliable on Windows, see https://github.com/Valve/fingerprintjs2/issues/375
       'enumerateDevices': true,
+      // Only a few browsers (such as Chrome, Edge) support this property, but the results are different for HTTPS and HTTP website.
+      'deviceMemory':true,
       // devicePixelRatio depends on browser zoom, and it's impossible to detect browser zoom
       'pixelRatio': true,
       // DNT depends on incognito mode for some browsers (Chrome) and it's impossible to detect incognito mode


### PR DESCRIPTION
Modify defaultOptions to exclude device memory by default.
Only a few browsers (such as Chrome, Edge) support this property,
but the results are different for HTTPS and HTTP website.
The browser will only return this value for trusted access like
HTTPS, localhost, or 127.0.0.1.

Compatibility: Different browser fingerprints will be generated by
default.